### PR TITLE
Fixing /walk [walk] bug

### DIFF
--- a/Client/Walk.lua
+++ b/Client/Walk.lua
@@ -24,13 +24,17 @@ function WalkCommandStart(source, args, raw)
   local name = firstToUpper(args[1])
 
   if name == "Reset" then
-      ResetPedMovementClipset(PlayerPedId()) return
+    ResetPedMovementClipset(PlayerPedId()) return
   end
 
-  local name2 = table.unpack(DP.Walks[name])
-  if name2 ~= nil then
+  if tableHasKey(DP.Walks,name) then
+    local name2 = table.unpack(DP.Walks[name])
     WalkMenuStart(name2)
   else
     EmoteChatMessage("'"..name.."' is not a valid walk")
   end
+end
+
+function tableHasKey(table, key)
+  return table[key] ~= nil
 end


### PR DESCRIPTION
The bug occurrs when typing for example /walk injured and it does not exist in the DP.Walks table. This will check if it exists first, then executes the unpacking function if it does exist.