### PR TITLE
Emote start event

### DIFF
--- a/Client/Emote.lua
+++ b/Client/Emote.lua
@@ -79,6 +79,13 @@ AddEventHandler('onResourceStop', function(resource)
   end
 end)
 
+-- Trigger an emote start with this event
+-- Parameter args: {"emotename"}
+RegisterNetEvent('EmoteCommandStart')
+AddEventHandler('EmoteCommandStart', function(args)
+  EmoteCommandStart(nil, args, nil)
+end)
+
 -----------------------------------------------------------------------------------------------------
 ------ Functions and stuff --------------------------------------------------------------------------
 -----------------------------------------------------------------------------------------------------

--- a/README.md
+++ b/README.md
@@ -10,3 +10,15 @@ start dpemotes
 Other instructions please check the fivem forum thread
 
 https://forum.fivem.net/t/dpemotes-356ish-emotes-usable-while-walking-props-and-more/843105
+
+### Emote trigger events
+
+Client sided emote trigger example:
+```lua
+TriggerEvent('EmoteCommandStart', {"handsup"})
+```
+
+Server sided emote trigger example:
+```lua
+TriggerClientEvent('EmoteCommandStart', source, {"handsup"})
+```


### PR DESCRIPTION
Hi there, I created an event that simply does the same as typing an emote in the chat using the /e command.
Through this event a script can start an emote, so script makers don't have to create an emote function themselves.

Also added 2 examples on how to trigger the event client & server sided in the readme.